### PR TITLE
- updated _metadata_to_df function

### DIFF
--- a/playground/example copy.ipynb
+++ b/playground/example copy.ipynb
@@ -1,0 +1,452 @@
+{
+ "cells": [
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Getting started with `scikit-talk`\n",
+    "\n",
+    "`scikit-talk` can be used to explore and analyse conversation files.\n",
+    "\n",
+    "It contains three main levels of objects:\n",
+    "\n",
+    "- Corpora; described with the `Corpus` class\n",
+    "- Conversations; described with the `Conversation` class\n",
+    "- Utterances; described with the `Utterance` class\n",
+    "\n",
+    "To explore the power of `scikit-talk`, the best entry point is a parser. With the parsers, we can load data into a `scikit-talk` object.\n",
+    "\n",
+    "`scikit-talk` currently has the following parsers:\n",
+    "\n",
+    "- `ChaFile.parse()`, which parsers .cha files.\n",
+    "\n",
+    "Future plans include the creation of parsers for:\n",
+    "\n",
+    "- .eaf files\n",
+    "- .TextGrid files\n",
+    "- .xml files\n",
+    "\n",
+    "Parsers return an object of the `Conversation` class.\n",
+    "\n",
+    "To get started with `scikit-talk`, import the module:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sktalk"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To see it in action, we will need to start with a transcription file.\n",
+    "\n",
+    "For example, you can download a file from the\n",
+    "[Griffith Corpus of Spoken Australian English](https://ca.talkbank.org/data-orig/GCSAusE/). This publicly available corpus contains transcription files in `.cha` format.\n",
+    "\n",
+    "We use the `ChaFile.parse` module to create the `Conversation` object:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<sktalk.corpus.conversation.Conversation at 0x105570040>"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "griffith01 = sktalk.Conversation.from_cha('GCSAusE_01.cha')\n",
+    "\n",
+    "griffith01"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "A parsed cha file is a conversation object. It has metadata, and a collection of utterances:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[Utterance(utterance='0', participant='S', time=[0, 1500], begin='00:00:00.000', end='00:00:01.500', metadata=None, utterance_clean='0', utterance_list=['0'], n_words=1, n_characters=1, time_to_next=None, dyadic=None, FTO=None),\n",
+       " Utterance(utterance=\"mm I'm glad I saw you⇗\", participant='S', time=[1500, 2775], begin='00:00:01.500', end='00:00:02.775', metadata=None, utterance_clean='mm Im glad I saw you', utterance_list=['mm', 'Im', 'glad', 'I', 'saw', 'you'], n_words=6, n_characters=15, time_to_next=None, dyadic=None, FTO=None),\n",
+       " Utterance(utterance=\"I thought I'd lost you (0.3)\", participant='S', time=[2775, 3773], begin='00:00:02.775', end='00:00:03.773', metadata=None, utterance_clean='I thought Id lost you 03', utterance_list=['I', 'thought', 'Id', 'lost', 'you', '03'], n_words=6, n_characters=19, time_to_next=None, dyadic=None, FTO=None),\n",
+       " Utterance(utterance=\"⌈no I've been here for a whi:le⌉,\", participant='H', time=[4052, 5515], begin='00:00:04.052', end='00:00:05.515', metadata=None, utterance_clean='no Ive been here for a while', utterance_list=['no', 'Ive', 'been', 'here', 'for', 'a', 'while'], n_words=7, n_characters=22, time_to_next=None, dyadic=None, FTO=None),\n",
+       " Utterance(utterance='⌊xxx⌋ (0.3)', participant='S', time=[4052, 5817], begin='00:00:04.052', end='00:00:05.817', metadata=None, utterance_clean='xxx 03', utterance_list=['xxx', '03'], n_words=2, n_characters=5, time_to_next=None, dyadic=None, FTO=None),\n",
+       " Utterance(utterance=\"⌊hm:: (.) if ʔI couldn't boʔrrow, (1.3) the second (0.2) book of readings fo:r\", participant='S', time=[6140, 9487], begin='00:00:06.140', end='00:00:09.487', metadata=None, utterance_clean='hm  if ʔI couldnt boʔrrow the second book of readings for', utterance_list=['hm', 'if', 'ʔI', 'couldnt', 'boʔrrow', 'the', 'second', 'book', 'of', 'readings', 'for'], n_words=11, n_characters=46, time_to_next=None, dyadic=None, FTO=None),\n",
+       " Utterance(utterance='commu:nicating acro-', participant='H', time=[12888, 14050], begin='00:00:12.888', end='00:00:14.050', metadata=None, utterance_clean='communicating acro', utterance_list=['communicating', 'acro'], n_words=2, n_characters=17, time_to_next=None, dyadic=None, FTO=None),\n",
+       " Utterance(utterance='no: for family gender and sexuality', participant='H', time=[14050, 17014], begin='00:00:14.050', end='00:00:17.014', metadata=None, utterance_clean='no for family gender and sexuality', utterance_list=['no', 'for', 'family', 'gender', 'and', 'sexuality'], n_words=6, n_characters=29, time_to_next=None, dyadic=None, FTO=None),\n",
+       " Utterance(utterance=\"+≋ ah: that's the second on is itʔ\", participant='S', time=[17014, 18611], begin='00:00:17.014', end='00:00:18.611', metadata=None, utterance_clean=' ah thats the second on is itʔ', utterance_list=['ah', 'thats', 'the', 'second', 'on', 'is', 'itʔ'], n_words=7, n_characters=23, time_to_next=None, dyadic=None, FTO=None),\n",
+       " Utterance(utterance=\"+≋ I think it's s⌈ame family gender⌉ has a second book\", participant='H', time=[18611, 21090], begin='00:00:18.611', end='00:00:21.090', metadata=None, utterance_clean=' I think its same family gender has a second book', utterance_list=['I', 'think', 'its', 'same', 'family', 'gender', 'has', 'a', 'second', 'book'], n_words=10, n_characters=39, time_to_next=None, dyadic=None, FTO=None)]"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "griffith01.utterances[:10]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'source': 'GCSAusE_01.cha',\n",
+       " 'UTF8': '',\n",
+       " 'PID': '11312/t-00017232-1',\n",
+       " 'Languages': ['eng'],\n",
+       " 'Participants': {'S': {'name': 'Sarah',\n",
+       "   'language': 'eng',\n",
+       "   'corpus': 'GCSAusE',\n",
+       "   'age': '',\n",
+       "   'sex': '',\n",
+       "   'group': '',\n",
+       "   'ses': '',\n",
+       "   'role': 'Adult',\n",
+       "   'education': '',\n",
+       "   'custom': ''},\n",
+       "  'H': {'name': 'Hannah',\n",
+       "   'language': 'eng',\n",
+       "   'corpus': 'GCSAusE',\n",
+       "   'age': '',\n",
+       "   'sex': '',\n",
+       "   'group': '',\n",
+       "   'ses': '',\n",
+       "   'role': 'Adult',\n",
+       "   'education': '',\n",
+       "   'custom': ''}},\n",
+       " 'Options': 'CA',\n",
+       " 'Media': '01, audio'}"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "griffith01.metadata"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Analyzing turn-taking dynamics\n",
+    "\n",
+    "When creating a `Conversation` object, a number of calculations and transformations are performed on the `Utterance` objects within.\n",
+    "For example, the number of words in each utterance is calculated, and stored under `Utterance.n_words`.\n",
+    "You can see this for a specific utterance as follows:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "⌈no I've been here for a whi:le⌉,\n",
+      "no Ive been here for a while\n",
+      "7\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(griffith01.utterances[3].utterance)\n",
+    "print(griffith01.utterances[3].utterance_clean)\n",
+    "print(griffith01.utterances[3].n_words)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "More sophisticated calculations can be performed, but do not happen automatically.\n",
+    "An example of this is the calculation of the Floor Transfer Offset (FTO) per utterance.\n",
+    "FTO is defined as the difference between the time that a turn starts, and the end of the most relevant prior turn by the other participant.\n",
+    "If there is overlap between these turns, the FTO is negative.\n",
+    "If there is a pause between these utterances, the FTO is positive.\n",
+    "\n",
+    "We can calculate the FTOs of the utterances in a conversation:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[0, 1500] S - FTO: None\n",
+      "[1500, 2775] S - FTO: None\n",
+      "[2775, 3773] S - FTO: None\n",
+      "[4052, 5515] H - FTO: 279\n",
+      "[4052, 5817] S - FTO: None\n",
+      "[6140, 9487] S - FTO: None\n",
+      "[12888, 14050] H - FTO: 3401\n",
+      "[14050, 17014] H - FTO: None\n",
+      "[17014, 18611] S - FTO: 0\n",
+      "[18611, 21090] H - FTO: 0\n"
+     ]
+    }
+   ],
+   "source": [
+    "griffith01.calculate_FTO()\n",
+    "\n",
+    "for utterance in griffith01.utterances[:10]:\n",
+    "    print(f'{utterance.time} {utterance.participant} - FTO: {utterance.FTO}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To determine which prior turn is the relevant turn for FTO calculation, the following criteria are used to find a relevant utterance prior to an utterance U:\n",
+    "\n",
+    "- the relevant utterance must be by another participant\n",
+    "- the relevant utterance must be the most recent utterance by that participant\n",
+    "- the relevant utterance must have started more than a specified number of ms before the start of U. This time defaults to 200 ms, but can be changed with the `planning_buffer` argument.\n",
+    "- the relevant utterance must be partly or entirely within the context window. The context window is defined as 10s (or 10000ms) prior to the utterance U. The size of this window can be changed with the `window` argument.\n",
+    "- within the context window, there must be a maximum of 2 speakers, which can be changed to 3 with the `n_participants` argument.\n",
+    "\n",
+    "When calculating the FTO, the settings for the arguments `planning_buffer`, `window`, and `n_participants` can be changed. Their values are stored in the metadata of the conversation object when the FTOs are calculated.\n",
+    "\n",
+    "They can be retrieved as follows:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'window': 10000, 'planning_buffer': 200, 'n_participants': 2}"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "griffith01.metadata[\"Calculations\"][\"FTO\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## The `Corpus` object\n",
+    "\n",
+    "A Corpus is a way to collect conversations.\n",
+    "\n",
+    "A Corpus can be initialized from a single conversation, or a list of conversations.\n",
+    "It can also be initialized as an empty object, with metadata."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'name': 'Griffith Corpus of Spoken Australian English',\n",
+       " 'url': 'https://ca.talkbank.org/data-orig/GCSAusE/'}"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "GCSAusE = sktalk.Corpus(name = \"Griffith Corpus of Spoken Australian English\",\n",
+    "                        url = \"https://ca.talkbank.org/data-orig/GCSAusE/\")\n",
+    "\n",
+    "GCSAusE.metadata"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can add conversations to a `Corpus`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[<sktalk.corpus.conversation.Conversation at 0x105570040>]"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "GCSAusE.append(griffith01)\n",
+    "\n",
+    "GCSAusE.conversations"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Storing and retrieving `Conversation` and `Corpus` objects\n",
+    "\n",
+    "\n",
+    "Both `Conversation` and `Corpus` objects can be written to file in .csv and .json formats.\n",
+    "\n",
+    "### json\n",
+    ".json files are comprehensive, and contain the entire object in one file:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Object saved to CGSAusE.json\n",
+      "Object saved to GCSAusE_01.json\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Corpus\n",
+    "GCSAusE.write_json(path = \"CGSAusE.json\")\n",
+    "\n",
+    "# Conversation\n",
+    "griffith01.write_json(path = \"GCSAusE_01.json\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The objects can be recreated from the .json files:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Corpus\n",
+    "GCSAusE_2 = sktalk.Corpus.from_json(\"CGSAusE.json\")\n",
+    "\n",
+    "# Conversation\n",
+    "griffith01_2 = sktalk.Conversation.from_json(path = \"CGSAusE_01.json\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### csv\n",
+    "\n",
+    "When writing to .csv, two files are created. One contains the utterances, and the other contains the metadata.\n",
+    "The former is named using the path provided, and the metadata file is named with the suffix `_metadata.csv` added."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Utterances saved to CGSAusE.csv\n",
+      "Metadata saved to CGSAusE_metadata.csv\n",
+      "Utterances saved to GCSAusE_01.csv\n",
+      "Metadata saved to GCSAusE_01_metadata.csv\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Corpus\n",
+    "GCSAusE.write_csv(path = \"CGSAusE.csv\")\n",
+    "\n",
+    "# Conversation\n",
+    "griffith01.write_csv(path = \"GCSAusE_01.csv\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.11"
+  },
+  "orig_nbformat": 4,
+  "vscode": {
+   "interpreter": {
+    "hash": "aee8b7b246df8f9039afb4144a1f6fd8d2ca17a180786b69acc140d282b71a49"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/sktalk/corpus/write/writer.py
+++ b/sktalk/corpus/write/writer.py
@@ -51,8 +51,16 @@ class Writer(abc.ABC):
     def _metadata_to_df(cls, metadata: dict):
         norm = pd.json_normalize(data=metadata, sep="_")
         df = pd.DataFrame(norm)
-        df[:] = np.vectorize(lambda x: ', '.join(
-            x) if isinstance(x, list) else x)(df)
+        
+        def process_element(x):
+            if isinstance(x, list):
+                return ', '.join(x)
+            elif isinstance(x, dict):
+                return json.dumps(x)  # or ', '.join([f'{k}: {v}' for k, v in x.items()])
+            else:
+                return x
+        
+        df[:] = np.vectorize(process_element)(df)
         return df
 
     @property

--- a/sktalk/corpus/write/writer.py
+++ b/sktalk/corpus/write/writer.py
@@ -53,11 +53,10 @@ class Writer(abc.ABC):
         df = pd.DataFrame(norm)
         
         def process_element(x):
-            if isinstance(x, list):
-                return ', '.join(x)
-            elif isinstance(x, dict):
-                return json.dumps(x)  # or ', '.join([f'{k}: {v}' for k, v in x.items()])
-            else:
+                if isinstance(x, list):
+                    return ', '.join(x)
+                if isinstance(x, dict):
+                    return json.dumps(x)  # or ', '.join([f'{k}: {v}' for k, v in x.items()])
                 return x
         
         df[:] = np.vectorize(process_element)(df)

--- a/sktalk/corpus/write/writer.py
+++ b/sktalk/corpus/write/writer.py
@@ -53,11 +53,11 @@ class Writer(abc.ABC):
         df = pd.DataFrame(norm)
         
         def process_element(x):
-                if isinstance(x, list):
-                    return ', '.join(x)
-                if isinstance(x, dict):
-                    return json.dumps(x)  # or ', '.join([f'{k}: {v}' for k, v in x.items()])
-                return x
+            if isinstance(x, list):
+                return ', '.join(x)
+            if isinstance(x, dict):
+                return json.dumps(x)  # or ', '.join([f'{k}: {v}' for k, v in x.items()])
+            return x
         
         df[:] = np.vectorize(process_element)(df)
         return df


### PR DESCRIPTION
Bug description:
write_csv encounters TypeError when metadata is provided in dict format.

Solution:
edited write_csv function that features press_element" function that loops over each element and handles lists, dicts, and strings, or "return as is".
Closes #69 

Error message:

TypeError Traceback (most recent call last)
in <cell line: 2>()
1 # Save the corpus as a .csv file locally
----> 2 Dutch_corpus.write_csv(path = "Dutch_corpus.csv")

8 frames
[/usr/local/lib/python3.10/dist-packages/sktalk/corpus/write/writer.py](https://46yu2lzt3ep-496ff2e9c6d22116-0-colab.googleusercontent.com/outputframe.html?vrz=colab_20240830-060131_RC00_669227538#) in (x)
52 norm = pd.json_normalize(data=metadata, sep="_")
53 df = pd.DataFrame(norm)
---> 54 df[:] = np.vectorize(lambda x: ', '.join(
55 x) if isinstance(x, list) else x)(df)
56 return df

TypeError: sequence item 0: expected str instance, dict found

Key Changes:
Added process_element function: This function handles three cases:
List: Joins the elements with ', '.
Dictionary: Converts the dictionary to a JSON string using json.dumps. Alternatively, you could convert the dictionary to a custom string format, e.g., by joining key-value pairs with a colon.
Other types: Returns the value as-is.
Replaced lambda with process_element: The np.vectorize now applies this more robust function to each element in the DataFrame.
This approach should resolve the TypeError by correctly handling cases where elements in the DataFrame are dictionaries.